### PR TITLE
Update procedure-types.ttl

### DIFF
--- a/schemes/procedure-types.ttl
+++ b/schemes/procedure-types.ttl
@@ -88,3 +88,11 @@ proctypes:AwardWithoutPriorPublication a skos:Concept ;
   skos:altLabel "Jednací řízení bez uveřejnění"@cs
   skos:topConceptOf proctypes:
   .
+  
+proctypes:Special a skos:Concept ;
+  skos:inScheme proctypes: ;
+  skos:prefLabel ""@cs, "Special procedure"@en ;
+  skos:definition ""@cs ,
+    "Procedure which cannot be classified within other procedure types"@en ;
+  skos:topConceptOf proctypes:
+  .


### PR DESCRIPTION
Good evening,
I'm conducting research about trasforming Italian public contracts data into linked Open Data, and I'm using your ontology. 
Italian laws include some special procedures for public contracts. They apply to a few public administrations, such as Parliament, Presidency of Republic, Supreme Court.  These procedures cannot be classified under any of the procedure types you specified. I would suggest to add a Special procedure type to make your schema more flexible. Anyone willing to use this procedure type, may be free to define a more precise concept by using skos:narrower . 

Thanks, 
Nicola Rustignoli.
